### PR TITLE
Separate hardware specific LCD panel code

### DIFF
--- a/lcd-panel-intro/Makefile
+++ b/lcd-panel-intro/Makefile
@@ -87,7 +87,7 @@ PROJECTNAME=lcd-panel-intro
 # (list all files to compile, e.g. 'a.c b.cpp as.S'):
 # Use .cc, .cpp or .C suffix for C++ files, use .S 
 # (NOT .s !!!) for assembly source code files.
-PRJSRC=main.c lcd.c vectors.c
+PRJSRC=rectangles.c lcd.c vectors.c
 
 # additional includes (e.g. -I/path/to/mydir)
 INC=-I/usr/local/include

--- a/lcd-panel-intro/Makefile
+++ b/lcd-panel-intro/Makefile
@@ -87,7 +87,7 @@ PROJECTNAME=lcd-panel-intro
 # (list all files to compile, e.g. 'a.c b.cpp as.S'):
 # Use .cc, .cpp or .C suffix for C++ files, use .S 
 # (NOT .s !!!) for assembly source code files.
-PRJSRC=rectangles.c lcd.c vectors.c
+PRJSRC=rectangles.c lcd.c vectors.c st7789.c
 
 # additional includes (e.g. -I/path/to/mydir)
 INC=-I/usr/local/include

--- a/lcd-panel-intro/lcd.c
+++ b/lcd-panel-intro/lcd.c
@@ -2,9 +2,6 @@
  *  Logic to operate a graphical LCD display
  */
 
-#include <avr/interrupt.h>
-#include <avr/io.h>
-#include <util/delay.h>
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -12,146 +9,6 @@
 #include "vectors.h"
 #include "utils.h"
 
-/********************************************************************/
-
-#define SWRESET             0x01
-#define SLPOUT              0x11
-#define COLMOD              0x3A
-#define MADCTL              0x36
-#define CASET               0x2A
-#define RASET               0x2B
-#define RAMWR               0x2C
-#define INVON               0x21
-#define NORON               0x13
-#define DISPON              0x29
-#define CMD_DELAY           0x80
-
-#define DCX_CMD                 0
-#define DCX_DATA                1
-
-#define SPI_QUEUE_LENGTH        64
-
-
-/********************************************************************/
-
-static void display_init (const uint8_t *cmd_list);
-static void send_command (uint8_t cmd, const uint8_t *params, uint8_t num_params);
-static void spi_enqueue (uint8_t message, unsigned int dcx_pin);
-static void write_command (uint8_t command);
-static void spi_write32 (uint32_t data);
-static void spi_write16 (uint16_t data);
-static void spi_write_byte (uint8_t data);
-
-
-/********************************************************************/
-
-/**
- *  LCD PANEL INITIALISATION CMD SEQUENCE
- *
- *  This list of commands is borrowed from the Adafruit ST7789 Arduino library
- *  which was written by Limor Fried/Ladyada.
- */
-static const uint8_t st7789_init_cmds [] = {
-    9,                          // 9 commands.
-    SWRESET, CMD_DELAY, 150,    // software reset, 150 ms delay
-    SLPOUT, CMD_DELAY, 10,      // out of sleep mode, 10 ms delay
-    COLMOD, 1 + CMD_DELAY,      // colour mode, 1 arg + delay
-        0x55,                   // 16 bit colour (rgb 565)
-        10,                     // 10 ms delay
-    MADCTL, 1,                  // memory access ctrl
-        0x00,
-    CASET, 4,                   // column addr set, 4 args
-        0,                      // xstart high bits
-        0,                      // xstart low bits
-        0,                      // xend high bits
-        240,                    // xend low bits
-    RASET, 4,                   // row addr set
-        0,                      // ystart high bits
-        0,                      // ystart low bits
-        320 >> 8,               // yend high bits
-        320 & 0xFF,             // yend low bits
-    INVON, CMD_DELAY, 10,       // invert display
-    NORON, CMD_DELAY, 10,       // normal (non-inverted) display
-    DISPON, CMD_DELAY, 10       // main screen on.
-};
-
-/********************************************************************/
-
-/**
- *  Initialise the SPI module in the ATmega328P so that we can talk to the
- *  LCD panel. Then initialise the LCD panel.
- *
- *  Note: Looking at the schematic for the DFRobot LCD panel breakout that
- *  I've got, it appears that the controller chip is only connected to be
- *  written to by the MCU, so I don't think I can read the value of any
- *  status registers. At least, not using the conventional SPI bus MOSI and
- *  MISO signals. The LCD controller only receives the MOSI from the MCU;
- *  MISO isn't connected.
- */
-    void
-lcd_init (void)
-{
-    // Set the DCX pin and CS pin to output mode.
-    DDRD |= 0x04 | 0x08 | 0x10;
-
-    // Set the pin mode on the MCU SPI MOSI and SCK to OUTPUT. Also set the
-    // SS pin to OUTPUT.
-    DDRB |= (0x04 | 0x08 | 0x20);
-
-    // Set the SPI CS pin to HIGH. Once we begin a transfer we will pull it
-    // low.
-    PORTD |= 0x08 | 0x10;
-
-    display_init (st7789_init_cmds);
-}
-
-/********************************************************************/
-
-/**
- *  Send the display initialisation commands over the SPI. Note that this
- *  code is borrowed from the Adafruit ST7789 library by Limor Fried/Ladyada.
- */
-    static void
-display_init (cmd_list)
-    const uint8_t *cmd_list;
-{
-    uint8_t command, num_args, delay_ms;
-
-    for (uint8_t num_commands = *(cmd_list ++); num_commands > 0; num_commands --)
-    {
-        command = *(cmd_list ++);
-        num_args = *(cmd_list ++);
-        delay_ms = num_args & CMD_DELAY;   // check if the flag is set to indicate a delay
-        num_args &= ~CMD_DELAY;
-        send_command (command, cmd_list, num_args);
-        cmd_list += num_args;
-
-        if (delay_ms != 0)
-        {
-            delay_ms = *(cmd_list ++);
-            _delay_ms (150);
-        }
-    }
-}
-
-/********************************************************************/
-
-/**
- *  Send a command followed by zero or more parameter bytes over the SPI.
- */
-    static void
-send_command (cmd, params, num_params)
-    uint8_t cmd;
-    const uint8_t *params;
-    uint8_t num_params;
-{
-    // send the command first
-    spi_enqueue (cmd, DCX_CMD);
-
-    // send the parameters
-    for (; num_params > 0; num_params --)
-        spi_enqueue (*(params ++), DCX_DATA);
-}
 
 /********************************************************************/
 
@@ -175,52 +32,6 @@ lcd_fill_colour (colour)
     for (int i = 0; i < SCREEN_ROWS; i ++)
     {
         write_colour (colour, SCREEN_COLUMNS);
-    }
-}
-
-/********************************************************************/
-
-/**
- *  Set the area of the display being used. Two points must be provided,
- *  which define a rectangular area of the display.
- */
-    void
-set_display_window (lower_left, upper_right)
-    const vector_t *lower_left, *upper_right;
-{
-    // get the range of columns being used from the x values.
-    // Starting column is from lower left, end column from upper right.
-    spi_enqueue (CASET, DCX_CMD);
-    spi_enqueue ((lower_left->x) >> 8, DCX_DATA);
-    spi_enqueue ((lower_left->x) & 0xFF, DCX_DATA);
-    spi_enqueue ((upper_right->x) >> 8, DCX_DATA);
-    spi_enqueue ((upper_right->x) & 0xFF, DCX_DATA);
-
-    // Same principle to get the window of rows we're using; it comes from the
-    // y values in the specified points.
-    spi_enqueue (RASET, DCX_CMD);
-    spi_enqueue ((lower_left->y) >> 8, DCX_DATA);
-    spi_enqueue ((lower_left->y) & 0xFF, DCX_DATA);
-    spi_enqueue ((upper_right->y) >> 8, DCX_DATA);
-    spi_enqueue ((upper_right->y) & 0xFF, DCX_DATA);
-
-    spi_enqueue (RAMWR, DCX_CMD);
-}
-
-/********************************************************************/
-
-/**
- *  Write colour pixels to the display.
- */
-    void
-write_colour (colour, pixel_count)
-    uint16_t colour;
-    uint32_t pixel_count;
-{
-    for (uint32_t i = 0; i < pixel_count; i ++)
-    {
-        spi_enqueue (colour >> 8, DCX_DATA);
-        spi_enqueue (colour & 0xFF, DCX_DATA);
     }
 }
 
@@ -258,7 +69,7 @@ write_line (start, end, colour)
     uint16_t colour;
 {
     int16_t dx, dy, err, ystep;
-    vector_t cursor, start_pos, end_pos;
+    vector_t cursor, steep_cursor, start_pos, end_pos;
 
     start_pos.x = start->x;
     start_pos.y = start->y;
@@ -303,7 +114,16 @@ write_line (start, end, colour)
     {
         ///////////////////////////////
         // handle the axes swap that we did earlier for steep lines.
-        steep? write_pixel (cursor.y, cursor.x, colour) : write_pixel (cursor.x, cursor.y, colour);
+        if (steep)
+        {
+            steep_cursor.x = cursor.y;
+            steep_cursor.y = cursor.x;
+            write_pixel (&steep_cursor, colour);
+        }
+        else
+        {
+            write_pixel (&cursor, colour);
+        }
 
         err -= dy;
 
@@ -321,117 +141,12 @@ write_line (start, end, colour)
  *  Set the pixel at the given x and y values to the given colour.
  */
     void
-write_pixel (x, y, colour)
-    uint16_t x;
-    uint16_t y;
+write_pixel (position, colour)
+    const vector_t *position;
     uint16_t colour;
 {
-    uint32_t xrange = ((uint32_t) x << 16) | x;
-    uint32_t yrange = ((uint32_t) y << 16) | y;
-
-    write_command (CASET);
-    spi_write32 (xrange);
-
-    write_command (RASET);
-    spi_write32 (yrange);
-
-    write_command (RAMWR);
-    spi_write16 (colour);
-}
-
-/********************************************************************/
-
-    static void
-write_command (command)
-    uint8_t command;
-{
-    // Set the DCX line LOW to indicate a command. DCX must be connected to port D
-    // pin 2.
-    PORTD &= ~0x04;
-    spi_write_byte (command);
-    PORTD |= 0x04;
-}
-
-/********************************************************************/
-
-    static void
-spi_write32 (data)
-    uint32_t data;
-{
-    spi_write_byte (data >> 24);
-    spi_write_byte (data >> 16);
-    spi_write_byte (data >> 8);
-    spi_write_byte (data);
-}
-
-/********************************************************************/
-
-    static void
-spi_write16 (data)
-    uint16_t data;
-{
-    spi_write_byte (data >> 8);
-    spi_write_byte (data);
-}
-
-/********************************************************************/
-
-    static void
-spi_write_byte (data)
-    uint8_t data;
-{
-    // Pull the CS line LOW
-    PORTD &= ~0x08;
-
-    SPCR |= (_BV (SPE) |  _BV (MSTR));
-    SPDR = data;
-
-    // wait until the SPI transfer is complete
-    while ((SPSR & _BV (SPIF)) == 0)
-        ;
-
-    PORTD |= 0x08;
-    SPCR &= ~_BV (SPE);
-}
-
-/********************************************************************/
-
-/**
- *  Accept data to be sent over the SPI bus.
- *
- *  If there's no SPI transfer in progress, this function will enable the
- *  SPI and place the message in the data register; bypassing the queue.
- *  Otherwise, this function will place the message on the tail of the
- *  queue.
- *
- *  If the queue is full, this function will wait until a queue slot is
- *  available.
- *
- *  Due to blocking on full queue, this function cannot be called with
- *  interrupts disabled (such as within an ISR).
- */
-    static void
-spi_enqueue (message, dcx_pin)
-    uint8_t message;
-    unsigned int dcx_pin;
-{
-    // Set the value on the DCX line. This is connected to port D
-    // pin 2.
-    PORTD = (dcx_pin == 1)? (PORTD | 0x04) : (PORTD & 0xFB);
-
-    // Pull the CS line LOW
-    PORTD &= ~0x08;
-
-    // no transfer in progress.
-    SPCR |= (_BV (SPE) |  _BV (MSTR));
-    SPDR = message;
-
-    // wait until the SPI transfer is complete
-    while ((SPSR & _BV (SPIF)) == 0)
-        ;
-
-    PORTD |= 0x08;
-    SPCR &= ~_BV (SPE);
+    set_display_window (position, position);
+    write_colour (colour, 1);
 }
 
 /********************************************************************/

--- a/lcd-panel-intro/lcd.h
+++ b/lcd-panel-intro/lcd.h
@@ -40,7 +40,7 @@
 
 void lcd_init (void);
 void lcd_fill_colour (uint16_t colour);
-void write_pixel (uint16_t x, uint16_t y, uint16_t colour);
+void write_pixel (const vector_t *position, uint16_t colour);
 void write_line (const vector_t *start, const vector_t *end, uint16_t colour);
 void draw_triangle (const vector_t *a, const vector_t *b, const vector_t *c, uint16_t colour);
 void set_display_window (const vector_t *lower_left, const vector_t *upper_right);

--- a/lcd-panel-intro/lcd.h
+++ b/lcd-panel-intro/lcd.h
@@ -43,6 +43,8 @@ void lcd_fill_colour (uint16_t colour);
 void write_pixel (uint16_t x, uint16_t y, uint16_t colour);
 void write_line (const vector_t *start, const vector_t *end, uint16_t colour);
 void draw_triangle (const vector_t *a, const vector_t *b, const vector_t *c, uint16_t colour);
+void set_display_window (const vector_t *lower_left, const vector_t *upper_right);
+void write_colour (uint16_t colour, uint32_t pixel_count);
 
 
 #endif // _LCD_H

--- a/lcd-panel-intro/rectangles.c
+++ b/lcd-panel-intro/rectangles.c
@@ -1,0 +1,109 @@
+/**
+ *  Simple program to draw rectangles on a display screen
+ */
+
+#include "lcd.h"
+#include "vectors.h"
+
+#include <avr/interrupt.h>
+#include <avr/sleep.h>
+#include <avr/io.h>
+
+/********************************************************************/
+
+//
+// List of colours to cycle through
+//
+const uint16_t colours_list [] = {
+    COLOUR_BLACK, COLOUR_NAVY, COLOUR_DARK_GREEN, COLOUR_DARK_CYAN,
+    COLOUR_MAROON, COLOUR_PURPLE, COLOUR_OLIVE, COLOUR_LIGHT_GREY,
+    COLOUR_DARK_GREY, COLOUR_BLUE, COLOUR_GREEN, COLOUR_CYAN, COLOUR_RED,
+    COLOUR_MAGENTA, COLOUR_YELLOW, COLOUR_ORANGE, COLOUR_WHITE, COLOUR_PINK,
+    COLOUR_SKY_BLUE
+};
+
+#define NUM_COLOURS     19
+
+static volatile int timer_interrupt;
+
+/********************************************************************/
+
+    int
+main (void)
+{
+    vector_t top, bottom;
+    int current_colour = 1;
+
+    bottom.x = 5;
+    bottom.y = 5;
+
+    lcd_init ();
+    lcd_fill_colour (0);
+
+    // setup timer 1 to use the /256 prescaler, TCCR1B register bits: x x x x x 1 0 0
+    // By using the /256 prescaler, there are 62,500 ticks per second (16 million / 256).
+    // One interrupt per 2^16 ticks, or approx 1.05 seconds.
+    TCCR1B = (TCCR1B & 0xF8) | 0x04;
+
+    // enable the timer interrupt
+    TIMSK1 |= 0x01;
+
+    timer_interrupt = 0;
+
+    for (;;)
+    {
+        if (timer_interrupt == 0)
+        {
+            sei ();
+            sleep_mode ();
+            continue;
+        }
+        else
+        {
+            timer_interrupt = 0;
+        }
+
+        top.x = bottom.x + 9;
+        top.y = bottom.y + 9;
+
+        set_display_window (&bottom, &top);
+        write_colour (colours_list [current_colour], 10 * 10);
+
+        bottom.x += 20;
+
+        // make sure the rectangle is still in bounds
+        if (bottom.x + 10 > SCREEN_COLUMNS)
+        {
+            bottom.x = 5;
+            bottom.y += 20;
+        }
+
+        if (bottom.y + 10 > SCREEN_ROWS)
+        {
+            lcd_fill_colour (0);
+            bottom.x = 5;
+            bottom.y = 5;
+            continue;
+        }
+
+        // cycle through the list of colours.
+        if (++ current_colour >= NUM_COLOURS)
+            current_colour = 1;
+    }
+
+    return 0;
+}
+
+/********************************************************************/
+
+/**
+ *  Timer interrupt, invoked roughly once per second.
+ */
+ISR (TIMER1_OVF_vect)
+{
+    timer_interrupt = 1;
+}
+
+/********************************************************************/
+
+/** vim: set ts=4 sw=4 et : */

--- a/lcd-panel-intro/st7789.c
+++ b/lcd-panel-intro/st7789.c
@@ -1,0 +1,250 @@
+/**
+ *  Hardware specific code for the ST7789 graphical LCD panel controller,
+ *  specifically for a 320 x 240 display.
+ */
+
+#include <avr/io.h>
+#include <avr/pgmspace.h>
+#include <util/delay.h>
+
+#include "lcd.h"
+#include "vectors.h"
+
+/********************************************************************/
+
+#define SWRESET             0x01
+#define SLPOUT              0x11
+#define COLMOD              0x3A
+#define MADCTL              0x36
+#define CASET               0x2A
+#define RASET               0x2B
+#define RAMWR               0x2C
+#define INVON               0x21
+#define NORON               0x13
+#define DISPON              0x29
+#define CMD_DELAY           0x80
+
+#define DCX_CMD                 0
+#define DCX_DATA                1
+
+
+/********************************************************************/
+
+static void display_init (const uint8_t *cmd_list);
+static void send_command (uint8_t cmd, const uint8_t *params, uint8_t num_params);
+static void write_command (uint8_t command);
+static void spi_transfer_byte (uint8_t message);
+static void spi_write32 (uint32_t data);
+static void spi_write16 (uint16_t data);
+
+
+/********************************************************************/
+
+/**
+ *  LCD PANEL INITIALISATION CMD SEQUENCE
+ *
+ *  This list of commands is borrowed from the Adafruit ST7789 Arduino library
+ *  which was written by Limor Fried/Ladyada.
+ */
+static const uint8_t PROGMEM st7789_init_cmds [] = {
+    9,                          // 9 commands.
+    SWRESET, CMD_DELAY, 150,    // software reset, 150 ms delay
+    SLPOUT, CMD_DELAY, 10,      // out of sleep mode, 10 ms delay
+    COLMOD, 1 + CMD_DELAY,      // colour mode, 1 arg + delay
+        0x55,                   // 16 bit colour (rgb 565)
+        10,                     // 10 ms delay
+    MADCTL, 1,                  // memory access ctrl
+        0x00,
+    CASET, 4,                   // column addr set, 4 args
+        0,                      // xstart high bits
+        0,                      // xstart low bits
+        0,                      // xend high bits
+        240,                    // xend low bits
+    RASET, 4,                   // row addr set
+        0,                      // ystart high bits
+        0,                      // ystart low bits
+        320 >> 8,               // yend high bits
+        320 & 0xFF,             // yend low bits
+    INVON, CMD_DELAY, 10,       // invert display
+    NORON, CMD_DELAY, 10,       // normal (non-inverted) display
+    DISPON, CMD_DELAY, 10       // main screen on.
+};
+
+/********************************************************************/
+
+/**
+ *  Initialise the SPI module in the ATmega328P so that we can talk to the
+ *  LCD panel. Then initialise the LCD panel.
+ *
+ *  Note: Looking at the schematic for the DFRobot LCD panel breakout that
+ *  I've got, it appears that the controller chip is only connected to be
+ *  written to by the MCU, so I don't think I can read the value of any
+ *  status registers. At least, not using the conventional SPI bus MOSI and
+ *  MISO signals. The LCD controller only receives the MOSI from the MCU;
+ *  MISO isn't connected.
+ */
+    void
+lcd_init (void)
+{
+    // Set the DCX pin and CS pin to output mode.
+    DDRD |= 0x04 | 0x08 | 0x10;
+
+    // Set the pin mode on the MCU SPI MOSI and SCK to OUTPUT. Also set the
+    // SS pin to OUTPUT.
+    DDRB |= (0x04 | 0x08 | 0x20);
+
+    // Set the SPI CS pin to HIGH. Once we begin a transfer we will pull it
+    // low.
+    PORTD |= 0x08 | 0x10;
+
+    display_init (st7789_init_cmds);
+}
+
+/********************************************************************/
+
+/**
+ *  Send the display initialisation commands over the SPI. Note that this
+ *  code is borrowed from the Adafruit ST7789 library by Limor Fried/Ladyada.
+ */
+    static void
+display_init (cmd_list)
+    const uint8_t *cmd_list;
+{
+    uint8_t command, num_args, delay_ms;
+
+    for (uint8_t num_commands = *(cmd_list ++); num_commands > 0; num_commands --)
+    {
+        command = *(cmd_list ++);
+        num_args = *(cmd_list ++);
+        delay_ms = num_args & CMD_DELAY;   // check if the flag is set to indicate a delay
+        num_args &= ~CMD_DELAY;
+        send_command (command, cmd_list, num_args);
+        cmd_list += num_args;
+
+        if (delay_ms != 0)
+        {
+            delay_ms = *(cmd_list ++);
+            _delay_ms (150);
+        }
+    }
+}
+
+/********************************************************************/
+
+/**
+ *  Send a command followed by zero or more parameter bytes over the SPI.
+ */
+    static void
+send_command (cmd, params, num_params)
+    uint8_t cmd;
+    const uint8_t *params;
+    uint8_t num_params;
+{
+    // send the command first
+    write_command (cmd);
+
+    // send the parameters
+    for (; num_params > 0; num_params --)
+        spi_transfer_byte (*(params ++));
+}
+
+/********************************************************************/
+
+    static void
+write_command (command)
+    uint8_t command;
+{
+    // pulling the DCX line low indicates to the controller that we're sending a
+    // command.
+    PORTD &= ~0x04;
+    spi_transfer_byte (command);
+    PORTD |= 0x04;
+}
+
+/********************************************************************/
+
+/**
+ *  Accept data to be sent over the SPI bus.
+ */
+    static void
+spi_transfer_byte (message)
+    uint8_t message;
+{
+    // Pull the CS line LOW
+    PORTD &= ~0x08;
+
+    SPCR |= (_BV (SPE) |  _BV (MSTR));
+    SPDR = message;
+
+    // wait until the SPI transfer is complete
+    while ((SPSR & _BV (SPIF)) == 0)
+        ;
+
+    PORTD |= 0x08;
+    SPCR &= ~_BV (SPE);
+}
+
+/********************************************************************/
+
+/**
+ *  Set the area of the display being used. Two points must be provided,
+ *  which define a rectangular area of the display.
+ */
+    void
+set_display_window (lower_left, upper_right)
+    const vector_t *lower_left, *upper_right;
+{
+    // get the range of columns being used from the x values.
+    // Starting column is from lower left, end column from upper right.
+    write_command (CASET);
+    spi_write16 (lower_left->x);
+    spi_write16 (upper_right->x);
+
+    // Same principle to get the window of rows we're using; it comes from the
+    // y values in the specified points.
+    write_command (RASET);
+    spi_write16 (lower_left->y);
+    spi_write16 (upper_right->y);
+
+    write_command (RAMWR);
+}
+
+/********************************************************************/
+
+/**
+ *  Write colour pixels to the display.
+ */
+    void
+write_colour (colour, pixel_count)
+    uint16_t colour;
+    uint32_t pixel_count;
+{
+    for (uint32_t i = 0; i < pixel_count; i ++)
+        spi_write16 (colour);
+}
+
+/********************************************************************/
+
+    static void
+spi_write32 (data)
+    uint32_t data;
+{
+    spi_transfer_byte (data >> 24);
+    spi_transfer_byte (data >> 16);
+    spi_transfer_byte (data >> 8);
+    spi_transfer_byte (data);
+}
+
+/********************************************************************/
+
+    static void
+spi_write16 (data)
+    uint16_t data;
+{
+    spi_transfer_byte (data >> 8);
+    spi_transfer_byte (data);
+}
+
+/********************************************************************/
+
+/** vim: set ts=4 sw=4 et : */


### PR DESCRIPTION
Code that's specific to the ST7789 graphical LCD controller is now in it's own C file, with a header file that defines the functions that the hardware specific module must implement. The hardware agnostic graphics code will only call functions defined in that header file. This provides a template that I can follow to support other display controllers.